### PR TITLE
Fixed Prototype Pollution

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -105,6 +105,9 @@ export class TransformOperationExecutor {
 
         } else if (typeof value === "object" && value !== null) {
 
+            // freezing the prototype to prevent prototype pollution
+            value.freeze(Object.prototype);
+
             // try to guess the type
             if (!targetType && value.constructor !== Object/* && TransformationType === TransformationType.CLASS_TO_PLAIN*/) targetType = value.constructor;
             if (!targetType && source) targetType = source.constructor;


### PR DESCRIPTION
:gear: **Fix:**

The fix is implemented by freezing the input `Object`'s `prototype`. I am not entirely sure this would fix the issue but this seemed like the most suitable solution.

:question: **How:**

The `classToPlainFromExist()` function has 3 parameters `object`, `plainObject`, and `options`. The `object` parameter is being used to inject the prototype as per the PoC:

```javascript
var root = require("class-transformer"); 
var payload = JSON.parse('{"__proto__": {"hjw": "jhu"}}');
root.classToPlainFromExist(payload,{}); 
console.log({}.hjw);
```

These values (with the payload) is passed to the `transform()` function in `TransformOperationExecutor()` class (_TransformOperationExecutor.ts_). Before using the `value` parameter when it's an `Object`, I used the `Object.freeze()` to freeze the prototype which prevents modifying the prototype.

```javascript
// freezing the prototype to prevent prototype pollution
value.freeze(Object.prototype);
```

**This fix is implemented with the help of this paper on Prototype Pollution:**

:spiral_notepad: [Prototype pollution attack in NodeJS application](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)

**From Mitigation Methods -> Freezing the prototype (from the paper):**
> The ECMAScript standard version 5 introduced a very interesting set of functionality to the
> JavaScript language. It allowed the definition of non-enumerable property, getter, setter and
> a lot more. One of API introduced was “Object.freeze”. When that function is called on an
> object, any further modification on that object will silently fail. Since the prototype of “Object”
> is an object, it’s possible to freeze it. Doing so will mitigate almost all the exploitable case.

<hr>

### :v: Fixed!

<hr>